### PR TITLE
Added ability to override css styling for hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
 						"type": "string",
 						"description": "Margin",
 						"default": "0 1"
+					},
+					"parameterHints.style": {
+						"type": "object",
+						"description": "Override styling for hints",
+						"default": {}
 					}
 				}
 			}

--- a/src/lib/hints.js
+++ b/src/lib/hints.js
@@ -46,6 +46,7 @@ class Hints {
         return paddings.join('px ') + 'px';
     }
     static paramHint(message, range) {
+        const style = workspace.getConfiguration('parameterHints.style');
         return {
             range,
             renderOptions: {
@@ -57,7 +58,8 @@ class Hints {
                     margin: `${Hints.margin()}position: relative; padding: ${Hints.padding()}; display: inline-block;`,
                     borderRadius: '5px',
                     fontStyle: 'italic',
-                    fontWeight: '400; font-size: 12px; line-height: 1;'
+                    fontWeight: '400; font-size: 12px; line-height: 1;',
+                    ...style
                 }
             }
         };


### PR DESCRIPTION
Hi @DominicVonk,

Love the extension!

I've add a commit to override the styling of hints (would like to modify things like font size, weight, style, etc)

I've never worked with vscode extensions before so I'm not sure if this is the correct/preferred way of doing it.

Thanks,
Peter

