### PR TITLE
Add usage example of color customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ Shows the parameter name of the called function
 
 ## Colors
 
+The background and foreground colors can be customized under 
+`workbench.colorCustomizations` like this:
+
+```js
+// settings.json
+{
+    // ...
+    "workbench.colorCustomizations": {
+        "parameterHints.hintBackground": "#37415180",
+        "parameterHints.hintForeground": "#9CA3AF"
+    },
+}
+```
+
 | Name | Description |
 ---|---
 |`parameterHints.hintForeground`|Specifies the foreground color for the hint|


### PR DESCRIPTION
The README does not really make it clear that color customizations have to go under `workbench.colorCustomizations`. I added a paragraph and an example to clarify that.

Closes #16 