### PR TITLE
feat: add configuration for fontSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Shows the parameter name of the called function
 |`parameterHints.languages`|Enable Parameter Hints only for the selected languages|`all`|
 |`parameterHints.padding`|Padding|`1 4`|
 |`parameterHints.margin`|Margin|`0 1`|
+|`parameterHints.fontSize`|Parameter Font Size|`1`|
 
 &nbsp;
 &nbsp;

--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
 						"type": "string",
 						"description": "Margin",
 						"default": "0 1"
+					},
+					"parameterHints.fontSize": {
+						"type": "number",
+						"description": "Parameter Font Size",
+						"default": 12
 					}
 				}
 			}

--- a/src/lib/hints.js
+++ b/src/lib/hints.js
@@ -45,6 +45,13 @@ class Hints {
         }
         return paddings.join('px ') + 'px';
     }
+
+    static fontSize() {
+        const currentState = workspace.getConfiguration('parameterHints');
+        const fontSize = currentState.get('fontSize') || 12;
+        return `${fontSize}px`
+    }
+    
     static paramHint(message, range) {
         return {
             range,
@@ -57,6 +64,7 @@ class Hints {
                     margin: `${Hints.margin()}position: relative; padding: ${Hints.padding()}; display: inline-block;`,
                     borderRadius: '5px',
                     fontStyle: 'italic',
+                    fontSize: Hints.fontSize(),
                     fontWeight: '400; font-size: 12px; line-height: 1;'
                 }
             }


### PR DESCRIPTION
This PR adds the parameter `fontSize` to the extension. You can set it to a smaller font size so it's less intrusive, but it defaults to 12, the regular VSCode font size.